### PR TITLE
add missing dependency on messages from this package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(${PROJECT_NAME}_ros
 )
 add_dependencies(${PROJECT_NAME}_ros
   ${PROJECT_NAME}_internal
+  ${PROJECT_NAME}_generate_messages_cpp
 )
 target_link_libraries(${PROJECT_NAME}_ros
   ${PROJECT_NAME}_internal


### PR DESCRIPTION
`octree_pa_node.cpp` compiled in this library uses the `OctomapPaFileName` service definition so it needs to declare a dependency one the generated messages/services.

This PR should fix the currently failing builds on the buildfarm such as http://build.ros.org/job/Lbin_uxhf_uXhf__octomap_pa__ubuntu_xenial_armhf__binary/8